### PR TITLE
feat: 各種コンストラクタ追加, FieldChild追加, コード整理

### DIFF
--- a/base/inc/Field.hpp
+++ b/base/inc/Field.hpp
@@ -3,29 +3,48 @@
 
 #include <vector>
 #include <string>
+#include <unordered_map>
 
 //p = {x, y}
 //pを交換
-typedef struct field_entities {
+struct ENT {
   int num; 
   int *p;  //座標
-} ENT;
+  ENT();
+  ENT(const int x, const int y, const int n);
+  ENT(const ENT& fe);
+  ENT(ENT&& fe);
+  ~ENT();
+  ENT& operator=(const ENT& fe);
+  ENT& operator=(ENT&& fe);
+};
 
 //ENTが変わっても変更する必要なし
 //ペアの数字
-typedef struct pair_entities {
+struct PENT {
   ENT *p1;
   ENT *p2;
-} PENT;
+  PENT();
+  PENT(const PENT& fe);
+  PENT(PENT&& fe);
+  ~PENT();
+  PENT& operator=(const PENT& fe);
+  PENT& operator=(PENT&& fe);
+};
 
 
 //fieldはENTを交換
 class Field {
 public:
+  static std::unordered_map<int, int> reallocation(Field &f);
+  static Field loadProblem(std::string path);
+  Field();
   Field(const int siz, const int *f);
   Field(const Field& f);
+  Field(Field &&f);
   ~Field();
-  Field& operator=(const Field &f);
+  Field& operator=(const Field& f);
+  Field& operator=(Field&& f);
   void print() const;
   int getSize() const;
   PENT getPair(const int num) const;
@@ -43,6 +62,7 @@ public:
   int isConfirm(const int *p) const;
   std::vector<std::string> getAnswer() const;
   int isEnd() const;
+  void reflection(const Field *f, const int px, const int py, const int as, std::unordered_map<int, int> corr);
 
 protected:
   int size;
@@ -52,14 +72,27 @@ protected:
   //confirm[size][size] 確定したら1、そうでないなら0
   int **confirm;
 
+  //デスストラクタから切り出し
+  void cleanup();
+
 /* private: */
 };
 
-Field* getProblem();
-void postAnswer();
-Field* loadProblem(std::string path);
+// Fieldの一部を分切り取って扱うクラス
+// FieldChild作成からreflection実行まで親Fieldの変更はしないほうがいい
+// 切り取った部分に孤立した数字があったらバグる
+// parentはdeleteしない
+class FieldChild : public Field {
+public:
+  FieldChild(Field *f, const int x, const int y, const int n);
+  void reflection();
+protected:
+  const int answer_size;
+  const int px, py;
+  Field *parent;
+  std::unordered_map<int, int> correspondence;
 
+};
 
 
 #endif
-

--- a/base/src/Field.cpp
+++ b/base/src/Field.cpp
@@ -8,6 +8,59 @@
 #include <sstream>
 #include <cstdlib>
 
+ENT::ENT(){}
+ENT::ENT(const int x, const int y, const int n) : num(n){
+  this->p = new int[2]{x, y};
+}
+ENT::ENT(const ENT& fe) : num(fe.num){
+  this->p = new int[2]{fe.p[0], fe.p[1]};
+}
+ENT::ENT(ENT&& fe) : num(fe.num), p(fe.p){
+  fe.p = nullptr;
+}
+ENT& ENT::operator=(const ENT& fe){
+  if(this == &fe) return *this;
+  this->p = new int[2]{fe.p[0], fe.p[1]};
+  this->num = fe.num;
+  return *this;
+}
+ENT& ENT::operator=(ENT&& fe){
+  if(this == &fe) return *this;
+  if(fe.p)  delete [] fe.p;
+  this->p = fe.p;
+  this->num = fe.num;
+  fe.p = nullptr;
+  return *this;
+}
+ENT::~ENT(){
+  if(this->p) delete [] this->p;
+}
+
+
+PENT::PENT(){}
+PENT::PENT(const PENT& fe) : p1(fe.p1), p2(fe.p2){ }
+PENT::PENT(PENT&& fe) : p1(fe.p1), p2(fe.p2){
+  fe.p1 = nullptr;
+  fe.p2 = nullptr;
+}
+PENT& PENT::operator=(const PENT& fe){
+  if(this == &fe) return *this;
+  this->p1 = fe.p1;
+  this->p2 = fe.p2;
+  return *this;
+}
+PENT& PENT::operator=(PENT&& fe){
+  if(this == &fe) return *this;
+  this->p1 = fe.p1;
+  this->p2 = fe.p2;
+  fe.p1 = nullptr;
+  fe.p2 = nullptr;
+  return *this;
+}
+PENT::~PENT(){ }
+
+
+Field::Field(){}
 Field::Field(const int siz, const int *f)
 : size(siz)
 {
@@ -31,9 +84,7 @@ Field::Field(const int siz, const int *f)
     this->confirm[y] = new int[siz]{};
     for(int x = 0; x < siz; x++){
       n = *(f + y * siz + x);
-      ent = new ENT;
-      ent->p = new int[2]{x, y};
-      ent->num = n;
+      ent = new ENT(x, y, n);
       this->field[y][x] = ent;
       if((len[n]++) == 0){
         //初めて出てきた数字
@@ -52,6 +103,7 @@ Field::Field(const int siz, const int *f)
 Field::Field(const Field& f)
 : size(f.size), answer(f.answer)
 {
+  std::cout << "test:copyField" << std::endl;
   //コピーコンストラクタ
   const int num_size = f.size * f.size / 2;
   std::vector<int> len(num_size, 0);
@@ -64,39 +116,39 @@ Field::Field(const Field& f)
     this->field[y] = new ENT*[f.size];
     this->confirm[y] = new int[f.size]{};
     for(x = 0; x < f.size; x++){
-      ENT *e = new ENT, *ent = f.field[y][x];
-      e->p = new int[2]{ent->p[0], ent->p[1]};
-      e->num = ent->num;
+      ENT *e = new ENT;
+      *e = *(f.field[y][x]);
       this->field[y][x] = e;
       this->confirm[y][x] = f.confirm[y][x];
       if((len[e->num]++) == 0){
-        this->pentities[e->num].p1 = ent;
+        this->pentities[e->num].p1 = e;
       }else {
-        this->pentities[e->num].p2 = ent;
+        this->pentities[e->num].p2 = e;
       }
     }
   }
 }
 
+Field::Field(Field&& f)
+: size(f.size), pentities(f.pentities), field(f.field),
+  answer(std::move(f.answer)), confirm(f.confirm)
+{
+  // ムーブコンストラクタ
+  f.pentities = nullptr;
+  f.field = nullptr;
+  f.confirm = nullptr;
+  f.size = 0;
+}
+
 Field::~Field(){
   //デストラクター
-  delete [] this->pentities;
-  for(int y = 0; y < this->size; y++){
-    for(int x = 0; x < this->size; x++){
-      delete [] this->field[y][x]->p;
-      delete this->field[y][x];
-    }
-    delete [] this->field[y];
-    delete [] confirm[y];
-  }
-  delete [] this->field;
-  delete [] confirm;
-
+  this->cleanup();
 }
 
 Field& Field::operator=(const Field &f){
-  //代入演算子"="のoverload
+  //コピー代入演算子
   if(this == &f)  return (*this); //自分が渡されたら処理しない
+  std::cout << "test:copyField" << std::endl;
 
   const int fsize = f.getSize();
   const int num_size = fsize * fsize / 2;
@@ -112,19 +164,58 @@ Field& Field::operator=(const Field &f){
     this->field[y] = new ENT*[fsize];
     this->confirm[y] = new int[fsize]{};
     for(x = 0; x < fsize; x++){
-      ENT *e = new ENT, *ent = f.get(x, y);
-      e->p = new int[2]{ent->p[0], ent->p[1]};
-      e->num = ent->num;
+      ENT *e = new ENT;
+      *e = *(f.get(x, y));
       this->field[y][x] = e;
       this->confirm[y][x] = f.isConfirm(x, y);
       if((len[e->num]++) == 0){
-        this->pentities[e->num].p1 = ent;
+        this->pentities[e->num].p1 = e;
       }else {
-        this->pentities[e->num].p2 = ent;
+        this->pentities[e->num].p2 = e;
       }
     }
   }
   return (*this);
+}
+
+Field& Field::operator=(Field&& f) {
+  //ムーブ代入演算子
+  if (this == &f) return *this;
+
+  this->cleanup();
+
+  size = f.size;
+  pentities = f.pentities;
+  field = f.field;
+  answer = std::move(f.answer);
+  confirm = f.confirm;
+
+  f.pentities = nullptr;
+  f.field = nullptr;
+  f.confirm = nullptr;
+  f.size = 0;
+  return *this;
+}
+
+void Field::cleanup(){
+  //動的確保したメモリの解放
+  if(this->pentities){
+    delete [] this->pentities;
+  }
+  if(this->field){
+    for(int y = 0; y < this->size; y++){
+      for(int x = 0; x < this->size; x++){
+        delete this->field[y][x];
+      }
+      delete [] this->field[y];
+    }
+    delete [] this->field;
+  }
+
+  if(this->confirm){
+    for(int y = 0; y < this->size; y++){ delete [] this->confirm[y]; }
+    delete [] this->confirm;
+  }
 }
 
 int Field::getSize() const{
@@ -162,6 +253,11 @@ void Field::print() const{
     for (int j = 0; j < this->size; j++){
       printf("(%d, %d)%c", this->field[i][j]->p[0], this->field[i][j]->p[1], " \n"[j == this->size - 1]);
     }
+  }
+
+  // pentities示
+  for(int i = 0; i < this->size * this->size / 2; i++){
+    printf("%d: p1={%d, %d, %d}, p2={%d, %d, %d}\n", i, this->pentities[i].p1->p[0], this->pentities[i].p1->p[1], this->pentities[i].p1->num, this->pentities[i].p2->p[0], this->pentities[i].p2->p[1], this->pentities[i].p2->num);
   }
 #endif
   std::cout << std::endl;
@@ -325,29 +421,37 @@ int Field::isEnd() const{
   return 1;
 }
 
-/* Field* getProblem(){ */
-/* } */
 
-Field* loadProblem(const std::string path){
-  std::ifstream ifs(path);
-  std::string str_buf;
-  std::vector<std::string> csvdata;
-  while (getline(ifs, str_buf)) {
-    csvdata.push_back(str_buf);
-  }
-  const int siz = csvdata.size();
-  int *field = new int[siz * siz];
+// 引数のFieldを自分に反映する
+void Field::reflection(const Field *f, const int px, const int py, const int as, std::unordered_map<int, int> corr){
 
-  for(int y = 0, x; y < siz; y++){
-    std::stringstream csvd{csvdata[y]};
-    x = 0;
-    while(getline(csvd, str_buf, ',')){
-      field[y*siz + x] = stoi(str_buf);
-      x++;
+  int x, y, n;
+  for(int dy = 0; dy < f->getSize(); dy++){
+    y = py + dy;
+    for(int dx = 0; dx < f->getSize(); dx++){
+      x = px + dx;
+      *(this->field[y][x]) = *(f->get(dx, dy));
+      this->field[y][x]->num = corr[this->field[y][x]->num];
+      this->confirm[y][x] = f->isConfirm(dx, dy);
+      n = this->field[y][x]->num;
+      if(this->pentities[n].p2 == nullptr){
+        this->pentities[n].p2 = this->field[y][x];
+      }else{
+        this->pentities[n].p1 = this->field[y][x];
+        this->pentities[n].p2 = nullptr;
+      }
     }
   }
-  return new Field(siz, field);
+
+  std::vector<std::string> ans = f->getAnswer();
+  int _as = as == -1 ? this->answer.size() : as;
+  int resize_size = ans.size() + _as;
+
+  if(this->answer.size() < resize_size){
+    this->answer.resize(resize_size);
+  }
+  for (int i = 0; i < ans.size(); ++i) {
+    this->answer[_as + i] = ans[i];
+  }
 }
 
-void postAnswer(){
-}

--- a/base/src/FieldChild.cpp
+++ b/base/src/FieldChild.cpp
@@ -1,0 +1,40 @@
+#include <Field.hpp>
+#include <unordered_map>
+
+FieldChild::FieldChild(Field *f, const int x, const int y, const int n)
+: parent(f), answer_size(f->getAnswer().size()), px(x), py(y)
+{
+  this->size = n;
+  this->field = new ENT**[n];
+  this->confirm = new int*[n];
+  ENT *ent;
+  for(int dy = 0; dy < n; dy++){
+    this->field[dy] = new ENT*[n];
+    this->confirm[dy] = new int[n]{};
+    for(int dx = 0; dx < n; dx++){
+      this->field[dy][dx] = new ENT;
+      *(this->field[dy][dx]) = *(f->get(x + dx, y + dy));
+      this->confirm[dy][dx] = f->isConfirm(x + dx, y + dy);
+    }
+  }
+  this->correspondence = Field::reallocation(*this);
+  const int numSize = correspondence.size();
+  this->pentities = new PENT[numSize];
+  int nn;
+  for(int dy = 0; dy < n; dy++){
+    for(int dx = 0; dx < n; dx++){
+      nn = this->field[dy][dx]->num;
+      if(this->pentities[nn].p1 == nullptr){
+        this->pentities[nn].p1 = this->field[dy][dx];
+      }else{
+        this->pentities[nn].p2 = this->field[dy][dx];
+      }
+    }
+  }
+
+}
+
+// 親Fieldに自身を反映させる
+void FieldChild::reflection(){
+  this->parent->reflection(this, this->px, this->py, this->answer_size, this->correspondence);
+}

--- a/base/src/Field_static.cpp
+++ b/base/src/Field_static.cpp
@@ -1,0 +1,52 @@
+#include <Field.hpp>
+#include <string>
+#include <fstream>
+#include <sstream>
+#include<iostream>
+
+// 数字の振り直し
+// map[置き換え後] = 置き換え前
+std::unordered_map<int, int> Field::reallocation(Field &f){
+  std::unordered_map<int, int> dic, dic_rev;
+  int i = 0;
+  ENT *ent;
+  for(int y = 0; y < f.getSize(); y++){
+    for(int x = 0; x < f.getSize(); x++){
+      ent = f.get(x, y);
+      if(dic_rev.find(ent->num) == dic_rev.end()){
+        dic_rev[ent->num] = i;
+        dic[i] = ent->num;
+        ent->num = i;
+        i++;
+      }else{
+        ent->num = dic_rev[ent->num];
+      }
+    }
+  }
+  return dic;
+}
+
+// csvファイルから問題を読み込み
+Field Field::loadProblem(const std::string path){
+  std::ifstream ifs(path);
+  std::string str_buf;
+  std::vector<std::string> csvdata;
+  while (getline(ifs, str_buf)) {
+    csvdata.push_back(str_buf);
+  }
+  const int siz = csvdata.size();
+  int *field = new int[siz * siz];
+
+  for(int y = 0, x; y < siz; y++){
+    std::stringstream csvd{csvdata[y]};
+    x = 0;
+    while(getline(csvd, str_buf, ',')){
+      field[y*siz + x] = stoi(str_buf);
+      x++;
+    }
+  }
+  Field f(siz, field);
+  return f;
+}
+
+

--- a/base/src/algo1.cpp
+++ b/base/src/algo1.cpp
@@ -300,7 +300,7 @@ void alg1(Field& f){
       if(next_stepF[i])  continue;
       //step数が同じ場合は最も少ない場所を優先する
       pairTo(i, 1);
-      pairP = f.getPair(f.get(tp[i][0], tp[i][1]))->p; //異常あり？
+      pairP = f.getPair(f.get(tp[i][0], tp[i][1]))->p;
       f.setConfirm(tp[i]);
       buf_s = serchShortestStep1(f, pairP, pairToP, buf_step);
       if(buf_s == -1){

--- a/base/src/main.cpp
+++ b/base/src/main.cpp
@@ -7,24 +7,23 @@
 
 int main(int argc, char *argv[]){
   std::chrono::system_clock::time_point  startTime, endTime;
-  Field *f;
   for(int i = 1; i < argc; i++){
     startTime = std::chrono::system_clock::now(); // 計測開始時間
-    f = loadProblem(argv[i]);
-    /* f->print(); */
-    alg1(*f);
-    /* f->print(); */
+    Field f = Field::loadProblem(argv[i]);
+    /* f.print(); */
+    alg1(f);
+    /* f.print(); */
     endTime = std::chrono::system_clock::now();  // 計測終了時間
-    if(!f->isEnd()){
+    if(!f.isEnd()){
       std::cout << "ERROR: is not End" << std::endl;
-      f->print();
+      f.print();
       return 1;
     }
     //統計取る場合はこれだけ表示
     std::cout << "file: " << argv[i] << std::endl;
-    std::cout << "size: " << f->getSize() << std::endl;
+    std::cout << "size: " << f.getSize() << std::endl;
     std::cout << "time[ms]: " << std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count() << std::endl;
-    std::cout << "answer step: " << f->getAnswer().size() << std::endl;
+    std::cout << "answer step: " << f.getAnswer().size() << std::endl;
     std::cout << std::endl;
 
 
@@ -32,7 +31,6 @@ int main(int argc, char *argv[]){
     /* for(std::string ans : f->getAnswer()){ */
     /*   std::cout << ans << std::endl; */
     /* } */
-    delete f;
   }
   return 0;
 }


### PR DESCRIPTION
# 追加
- ENT, PENT, Fieldのムーブ・コピーコンストラクタなど
- Fieldを縮小して扱うクラスChildField
- Fieldの数字を振り直す静的関数reallocation

# 改善
- 静的関数を別ファイルに分割
- コピー代入演算子でのpentitiesが正しくコピーされない不具合の修正
- その他コンストラクタ追加によるコードの最適化


# 備考
- テストは最小限しか行えていないため、不具合が発生する可能性はある
- FieldChildはは切り取る部分が一つの問題として扱えないとバグる(確認するプログラムは作っていない)